### PR TITLE
Fix critical vulnerability in #43, immediate patch

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -28,4 +28,4 @@ jobs:
         pip install -r ./dev-requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint sqlite_database --rcfile dev-config/pylint.toml
+        pylint sqlite_database --rcfile dev-config/pylint.toml --format github

--- a/sqlite_database/__init__.py
+++ b/sqlite_database/__init__.py
@@ -15,7 +15,7 @@ def test_installed():
     return True
 
 
-__version__ = "0.7.9"
+__version__ = "0.7.10"
 __all__ = [
     "Database",
     "Table",

--- a/sqlite_database/_utils.py
+++ b/sqlite_database/_utils.py
@@ -112,7 +112,9 @@ def check_one(data: str):
     """check one to check if a string contains illegal character OR
     if it is a reserved SQL keyword"""
     if matches(_re_valid, data) is True:
-        raise SecurityError("Cannot parse unsafe data.")
+        exc = SecurityError("Cannot parse unsafe data.")
+        exc.add_note(f"Target: {data}")
+        raise exc
     if data.upper() in _SQLITE_KEYWORDS:
         raise SecurityError(f'"{data}" is a reserved SQL keyword and cannot be used.')
     return data

--- a/sqlite_database/query_builder.py
+++ b/sqlite_database/query_builder.py
@@ -222,6 +222,7 @@ def extract_signature(  # pylint: disable=too-many-locals
     data: dict[str, Any] = {}
 
     for key, value in filter_.items():
+        check_one(key)
         condition_id = generate_ids()
         if not isinstance(value, Signature):
             value = Signature(value, "=")


### PR DESCRIPTION
Implement a security check to prevent SQL injection by adding `check_one(key)` in the relevant function. Update the error handling in `check_one` to provide more context on unsafe data. Additionally, update the version number to reflect the changes made.

Fixes #43