### PR TITLE
feat: auto-increment support for columns & models

### DIFF
--- a/luminadb/models/__init__.py
+++ b/luminadb/models/__init__.py
@@ -66,6 +66,7 @@ class BaseModel:  # pylint: disable=too-few-public-methods,too-many-public-metho
         }  # pylint: disable=no-member
         cls.__table_name__ = cls.__table_name__ or cls.__name__.lower()
         _primary = None
+        _primary_auto = False
 
         # Extract constraints from __schema__
         for constraint in cls.__schema__:  # pylint: disable=no-member
@@ -75,6 +76,11 @@ class BaseModel:  # pylint: disable=too-few-public-methods,too-many-public-metho
                 raise ConstraintError("Cannot apply when a column has 2 primary keys")
             if isinstance(constraint, Primary):
                 _primary = target_col
+                # remember if primary has auto-increment enabled
+                try:
+                    _primary_auto = constraint.auto  # type: ignore
+                except TypeError:
+                    _primary_auto = False
                 continue
 
         # Process fields & constraints
@@ -95,6 +101,9 @@ class BaseModel:  # pylint: disable=too-few-public-methods,too-many-public-metho
             columns.append(col)
 
         cls._primary = _primary
+        # Remember whether primary requested auto-increment so create()
+        # can handle instantiation and post-insert assignment accordingly.
+        cls._primary_auto = bool(_primary_auto)
         try:
             cls._tbl = db.create_table(cls.__table_name__, columns)
         except DatabaseExistsError:
@@ -156,14 +165,33 @@ class BaseModel:  # pylint: disable=too-few-public-methods,too-many-public-metho
         """Create data based on kwargs"""
         primary: str | None = cls._primary or kwargs.get("id", None)
         id_present = bool(kwargs.get(cls._primary or "id", None))
-        if primary and cls.__auto_id__ and not id_present:  # type: ignore
-            kwargs[primary] = cls.__auto_id__()  # type: ignore
+
+        # If primary is auto-incremented by DB, do not call model-level
+        # __auto_id__. Instead, instantiate with a temporary None for the
+        # primary so dataclass __init__ accepts it, then perform the insert
+        # and set the real id on the instance from the DB's lastrowid.
+        use_db_autoinc = bool(primary and getattr(cls, "_primary_auto", False) and not id_present)
+
+        if use_db_autoinc:
+            kwargs[primary] = None  # type: ignore # allow dataclass instantiation
+        else:
+            if primary and cls.__auto_id__ and not id_present:  # type: ignore
+                kwargs[primary] = cls.__auto_id__()  # type: ignore
+
         instance = cls(**kwargs)
 
         cls._execute_hooks("before_create", instance)
         for key in kwargs:
             cls._execute_validators(key, instance)
-        cls._tbl.insert(kwargs)
+
+        lastrow = cls._tbl.insert(kwargs)
+        if use_db_autoinc:
+            # Assign generated id back to instance attribute
+            try:
+                setattr(instance, primary, lastrow) # type: ignore
+            except (TypeError, AttributeError):
+                pass
+
         cls._execute_hooks("after_create", instance)
         return instance
 

--- a/luminadb/models/__init__.py
+++ b/luminadb/models/__init__.py
@@ -182,7 +182,7 @@ class BaseModel:  # pylint: disable=too-few-public-methods,too-many-public-metho
 
         cls._execute_hooks("before_create", instance)
         for key in kwargs:
-            if key == primary and use_db_autoinc:
+            if key == primary and use_db_autoinc: # This is a naive changes.
                 continue
             cls._execute_validators(key, instance)
 

--- a/luminadb/models/__init__.py
+++ b/luminadb/models/__init__.py
@@ -182,6 +182,8 @@ class BaseModel:  # pylint: disable=too-few-public-methods,too-many-public-metho
 
         cls._execute_hooks("before_create", instance)
         for key in kwargs:
+            if key == primary and use_db_autoinc:
+                continue
             cls._execute_validators(key, instance)
 
         lastrow = cls._tbl.insert(kwargs)

--- a/luminadb/models/__init__.py
+++ b/luminadb/models/__init__.py
@@ -182,7 +182,11 @@ class BaseModel:  # pylint: disable=too-few-public-methods,too-many-public-metho
 
         cls._execute_hooks("before_create", instance)
         for key in kwargs:
-            if key == primary and use_db_autoinc: # This is a naive changes.
+            # Below is a naive changes
+            # When validating input, it skips primary key if it detects SQL is going to handle it internally.
+            # If it's "enough," no changes should be made.
+            # But I don't believe it.
+            if key == primary and use_db_autoinc:
                 continue
             cls._execute_validators(key, instance)
 

--- a/luminadb/models/helpers.py
+++ b/luminadb/models/helpers.py
@@ -198,7 +198,6 @@ def validate(fn_or_column, reason=None):
     """Register a validator"""
 
     def decorator(func: Callable):
-        print(func, fn_or_column)
         fn = staticmethod(func)
         name = func.__name__
         inferred_col = (

--- a/luminadb/models/helpers.py
+++ b/luminadb/models/helpers.py
@@ -118,11 +118,27 @@ class Foreign(Constraint):
 
 
 class Primary(Constraint):
-    """Primary constraint"""
+    """Primary constraint
+
+    Accepts optional `auto` flag to enable auto-increment on integer
+    primary columns when using the BuilderColumn API.
+    """
+
+    def __init__(self, column: str, auto: bool = False) -> None:
+        super().__init__(column)
+        self._auto = bool(auto)
+
+    @property
+    def auto(self) -> bool:
+        return self._auto
 
     def apply(self, type_: BuilderColumn):
-        """Apply this constraint as primary"""
+        """Apply this constraint as primary. If `auto` was requested,
+        enable auto increment on the builder column as well.
+        """
         type_.primary()
+        if self._auto:
+            type_.auto_increment()
 
 
 class Validators:

--- a/tests/database/model_api/test_model_api.py
+++ b/tests/database/model_api/test_model_api.py
@@ -262,3 +262,17 @@ def test_model_api_custom_id():
         username: str
 
     assert Users.create(uid="1", username='admin')
+
+def test_model_api_auto_increment():
+    """Test Model API Auto Increment"""
+
+    db = Database(":memory:")
+
+    @model(db)
+    class Users(BaseModel):
+        __schema__ = (Primary('id', auto=True),)
+        __auto_id__ = lambda: 1
+        id: int
+        username: str
+
+    assert Users.create(username='admin')

--- a/tests/database/table_api/test_autoincrement.py
+++ b/tests/database/table_api/test_autoincrement.py
@@ -1,0 +1,35 @@
+"""Tests for auto increment feature"""
+
+from pytest import raises
+
+from luminadb import Database, integer, text
+from luminadb.column import Column
+
+
+def test_column_constructor_autoinc_non_integer_raises():
+    """Column(...) with auto_increment on non-integer must raise"""
+    with raises(ValueError):
+        Column("a", "text", auto_increment=True)
+
+
+def test_builder_autoinc_on_defined_non_integer_raises():
+    """BuilderColumn.auto_increment must raise if type already non-integer"""
+    with raises(ValueError):
+        # text(...) already defines type as text
+        text("a").auto_increment()
+
+
+def test_create_table_and_insert_autoincrement_integer():
+    """Creating a table with INTEGER PRIMARY AUTOINCREMENT should auto increment ids"""
+    db = Database(":memory:")
+    t = db.create_table("t_autoinc", [integer("id").primary().auto_increment(), text("name")])
+
+    # Insert without id should let sqlite assign autoincrement values
+    first = t.insert({"name": "alice"})
+    second = t.insert({"name": "bob"})
+
+    assert first == 1
+    assert second == 2
+
+    ids = t.select(what="id")
+    assert ids == [1, 2]


### PR DESCRIPTION
This PR adds auto-increment support across the library:
- Column/BuilderColumn: add auto_increment flag and builder method
- Query builder: emit inline PRIMARY KEY + AUTOINCREMENT for single-column primary keys
- extract_table parsing improved to avoid duplicate/conflicting primary definitions and properly parse foreign keys
- Models: Primary(..., auto=True) enables DB autoincrement; Model.create() handles DB-assigned ids and avoids using model-level `__auto_id__` when DB autoinc is used
- Added tests: 	tests/database/table_api/test_autoincrement.py